### PR TITLE
Add option for globby to include directories

### DIFF
--- a/rename.js
+++ b/rename.js
@@ -111,7 +111,7 @@ function getFileArray(files) {
     return f.replace(/\[/g, '\\[').replace(/\]/g, '\\]');
   });
   if (globby.hasMagic(files)) {
-    files = globby.sync(files);
+    files = globby.sync(files, { onlyFiles: false });
   }
   return files;
 }


### PR DESCRIPTION
Thanks a lot for the `--ignore-directories` option! As it turned out, after upgrading `globby` from `6.1.0` to `11.0.0`, directories are already ignored by default by `globby` since [`7.0.0`](https://github.com/sindresorhus/globby/releases/tag/v7.0.0):

> The `nodir` option is now also `true` by default. This means that by default it will now only return file paths, not directory paths.

I figured this out after discovering that the `--ignore-directories` option had no effect and then debugging your tool locally because I couldn't figure out how [your commit](https://github.com/jhotmann/node-rename-cli/commit/0bcf1708b09500782addcd989f52bd7bff387f4f) would have changed that. It seems that the option `nodir` no longer exists (thanks to the TypeScript compiler in Visual Studio Code I already had an error before even trying 🎉) and `onlyFiles` is the right option to use.

Strictly speaking, your 6.1.0 release had thus a breaking change and should have been tagged 7.0.0. While this issue was quite subtle, it would be nice to have unit tests to catch regressions like this. But overall I really like this tool so I stop complaining! 🤭 🤓