### PR TITLE
Fix the alias for the ignore directories option

### DIFF
--- a/lib/yargsOptions.js
+++ b/lib/yargsOptions.js
@@ -46,7 +46,7 @@ module.exports = {
     describe: 'Do not append an index when renaming multiple files',
     showInUi: true
   }, 'd': {
-    alias: 'ignoredirectories',
+    alias: 'ignore-directories',
     boolean: true,
     describe: 'Do not rename directories',
     showInUi: true


### PR DESCRIPTION
If you prefer `--ignoredirectories`, you can close this pull request and fix the alias in the README instead. The currently documented option does not work.